### PR TITLE
fix(crypto): fix transaction builder pattern

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -10694,7 +10694,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],
       ["ngrok", [
         ["npm:3.4.0", {
-          "packageLocation": "./.yarn/cache/ngrok-npm-3.4.0-b3c3175e0b-7edb48c174.zip/node_modules/ngrok/",
+          "packageLocation": "./.yarn/unplugged/ngrok-npm-3.4.0-b3c3175e0b/node_modules/ngrok/",
           "packageDependencies": [
             ["ngrok", "npm:3.4.0"],
             ["@types/node", "npm:8.10.66"],
@@ -12212,7 +12212,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],
       ["protobufjs", [
         ["npm:6.10.2", {
-          "packageLocation": "./.yarn/cache/protobufjs-npm-6.10.2-f0f2cab7fe-09d6292362.zip/node_modules/protobufjs/",
+          "packageLocation": "./.yarn/unplugged/protobufjs-npm-6.10.2-f0f2cab7fe/node_modules/protobufjs/",
           "packageDependencies": [
             ["protobufjs", "npm:6.10.2"],
             ["@protobufjs/aspromise", "npm:1.1.2"],

--- a/packages/guardian-crypto/__tests__/unit/builders/guardian-group-permissions.test.ts
+++ b/packages/guardian-crypto/__tests__/unit/builders/guardian-group-permissions.test.ts
@@ -31,6 +31,17 @@ describe("Guardian Group Permissions tests", () => {
             expect(actual.verify()).toBeTrue();
         });
 
+        it("should verify correctly when Asset method is not on top", () => {
+            const actual = new GuardianGroupPermissionsBuilder()
+                .vendorField("guardian-group-permissions transaction")
+                .nonce("4")
+                .GuardianGroupPermissions(groupPermission)
+                .sign(passphrases[0]!);
+
+            expect(actual.build().verified).toBeTrue();
+            expect(actual.verify()).toBeTrue();
+        });
+
         it("object should remain the same if asset is undefined", () => {
             const actual = new GuardianGroupPermissionsBuilder();
             actual.data.asset = undefined;

--- a/packages/guardian-crypto/__tests__/unit/builders/guardian-user-permissions.test.ts
+++ b/packages/guardian-crypto/__tests__/unit/builders/guardian-user-permissions.test.ts
@@ -30,6 +30,17 @@ describe("Guardian User Permissions tests", () => {
             expect(actual.verify()).toBeTrue();
         });
 
+        it("should verify correctly when Asset method is not on top", () => {
+            const actual = new GuardianUserPermissionsBuilder()
+                .vendorField("guardian-user-permissions transaction")
+                .nonce("4")
+                .GuardianUserPermissions(userPermission)
+                .sign(passphrases[0]!);
+
+            expect(actual.build().verified).toBeTrue();
+            expect(actual.verify()).toBeTrue();
+        });
+
         it("object should remain the same if asset is undefined", () => {
             const actual = new GuardianUserPermissionsBuilder();
             actual.data.asset = undefined;

--- a/packages/guardian-crypto/src/builders/guardian-base-builder.ts
+++ b/packages/guardian-crypto/src/builders/guardian-base-builder.ts
@@ -3,9 +3,9 @@ import { Interfaces, Transactions } from "@arkecosystem/crypto";
 import { defaults } from "../defaults";
 import { GuardianTransactionGroup } from "../enums";
 
-export abstract class GuardianBaseTransactionBuilder<TBuilder> extends Transactions.TransactionBuilder<
-    GuardianBaseTransactionBuilder<TBuilder>
-> {
+export abstract class GuardianBaseTransactionBuilder<
+    TBuilder extends Transactions.TransactionBuilder<TBuilder>
+> extends Transactions.TransactionBuilder<TBuilder> {
     protected constructor() {
         super();
         this.data.version = defaults.version;


### PR DESCRIPTION
… have to be first

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
This PR fixes transaction builder pattern.

### What changes are being made?
I changed that extended generic is of type abstract builder not abstract guardian builder.

### Why are these changes necessary?
```ts
 const actual = new GuardianGroupPermissionsBuilder()
                .vendorField("guardian-group-permissions transaction")
                .nonce("4")
                .GuardianGroupPermissions(groupPermission)
                .sign(passphrases[0]!);
```
Make it possible to use asset method anywhere you want before build or sign.

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

